### PR TITLE
Fix typo

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -300,7 +300,7 @@ static std::unordered_map<int, std::string> status_codes = {
   { 415, "Unsupported Media Type" },
   { 416, "Request Range Not Satisfiable" },
   { 417, "Expectation Failed" },
-  { 418, "I""m a teapot" },
+  { 418, "I'm a teapot" },
   { 422, "Unprocessable Entity" },
   { 423, "Locked" },
   { 424, "Failed Dependency" },


### PR DESCRIPTION
`"I""m a teapot"` -> `"I'm a teapot"`