### PR TITLE
Fix static path prefix matching

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -776,8 +776,8 @@ inline static_path_resolution resolve_static_path(
     };
   }
 
-  auto res = std::mismatch(request_uri.begin(), request_uri.end(), mount_path.begin());
-  if (res.first != request_uri.begin() + mount_path.size()) {
+  if (request_uri.size() < mount_path.size()
+      || request_uri.compare(0, mount_path.size(), mount_path) != 0) {
     return static_path_resolution{
       .matched = false,
       .forbidden = false,

--- a/test.cxx
+++ b/test.cxx
@@ -457,6 +457,11 @@ void test_clask_static_path_resolution() {
     _ok(result.forbidden == false, R"(result.forbidden == false)");
   }
   {
+    auto result = clask::resolve_static_path("/sta", "/static/", "./public");
+    _ok(result.matched == false, R"(result.matched == false)");
+    _ok(result.forbidden == false, R"(result.forbidden == false)");
+  }
+  {
     auto result = clask::resolve_static_path("/static/%2e%2e/secret.txt", "/static/", "./public");
     _ok(result.matched == true, R"(result.matched == true)");
     _ok(result.forbidden == true, R"(result.forbidden == true)");


### PR DESCRIPTION
Fixes static file route matching for request paths shorter than the configured mount path. Adds coverage for short non-matching paths.