### PR TITLE
Fix multipart body parsing

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -1075,20 +1075,25 @@ inline bool request::parse_multipart(std::vector<part>& parts) {
   if (boundary.empty()) {
     return false;
   }
-  boundary = "--" + boundary;
+  const auto delimiter = "--" + boundary;
 
-  size_t pos = 0;
-  while (true) {
-    auto next = body.find(boundary + "\r\n", pos + 1);
+  size_t pos = body.find(delimiter);
+  while (pos != std::string::npos) {
+    auto part_start = pos + delimiter.size();
+    if (body.compare(part_start, 2, "--") == 0) {
+      break;
+    }
+    if (body.compare(part_start, 2, "\r\n") != 0) {
+      return false;
+    }
+    part_start += 2;
+
+    auto next = body.find("\r\n" + delimiter, part_start);
     if (next == std::string::npos) {
-      next = body.find(boundary + "--\r\n", pos + 1);
-      if (next == std::string::npos) {
-        break;
-      }
-      boundary += "--";
+      return false;
     }
 
-    auto data = body.substr(pos + boundary.size(), next);
+    auto data = body.substr(part_start, next - part_start);
 
     auto eos = data.find("\r\n\r\n");
     if (eos == std::string::npos) {
@@ -1122,11 +1127,7 @@ inline bool request::parse_multipart(std::vector<part>& parts) {
       .body = data = data.substr(eos + 4)
     };
     parts.emplace_back(std::move(p));
-    pos = next + boundary.size() + 1;
-    if ((body.at(pos) == '-' && body.at(pos + 1) == '-'
-        && body.at(pos + 2) == '\n') || body.at(pos) != '\n') {
-      break;
-    }
+    pos = next + 2;
   }
   return true;
 }

--- a/test.cxx
+++ b/test.cxx
@@ -65,6 +65,7 @@ void test_clask_request_parse_multipart2() {
   _ok(result == true, R"(result == true)");
   _ok(parts.size() == 1, R"(parts.size() == 1)");
   _ok(parts[0].name() == "field1", R"(parts[0].name() == "field1")");
+  _ok(parts[0].body == "value1", R"(parts[0].body == "value1")");
 }
 
 void test_clask_request_parse_multipart3() {
@@ -90,6 +91,38 @@ void test_clask_request_parse_multipart3() {
   _ok(parts.size() == 1, R"(parts.size() == 1)");
   _ok(parts[0].name() == "field1", R"(parts[0].name() == "field1")");
   _ok(parts[0].filename() == "README.md", R"(parts[0].filename() == "README.md")");
+  _ok(parts[0].body == "value1", R"(parts[0].body == "value1")");
+}
+
+void test_clask_request_parse_multipart5() {
+  std::vector<clask::part> parts;
+  bool result;
+
+  parts.clear();
+  clask::request req(
+      "GET",
+      "/",
+      "/",
+      {},
+      {
+        { "Content-Type", R"(multipart/form-data;boundary="boundary")" },
+      },
+      "--boundary\r\n"
+      "Content-Disposition: form-data; name=\"field1\"\r\n"
+      "\r\n"
+      "value1\r\n"
+      "--boundary\r\n"
+      "Content-Disposition: form-data; name=\"field2\"\r\n"
+      "\r\n"
+      "value2\r\n"
+      "--boundary--\r\n");
+  result = req.parse_multipart(parts);
+  _ok(result == true, R"(result == true)");
+  _ok(parts.size() == 2, R"(parts.size() == 2)");
+  _ok(parts[0].name() == "field1", R"(parts[0].name() == "field1")");
+  _ok(parts[0].body == "value1", R"(parts[0].body == "value1")");
+  _ok(parts[1].name() == "field2", R"(parts[1].name() == "field2")");
+  _ok(parts[1].body == "value2", R"(parts[1].body == "value2")");
 }
 
 void test_clask_request_parse_multipart4() {
@@ -501,6 +534,7 @@ int main() {
   subtest("test_clask_request_parse_multipart2", test_clask_request_parse_multipart2);
   subtest("test_clask_request_parse_multipart3", test_clask_request_parse_multipart3);
   subtest("test_clask_request_parse_multipart4", test_clask_request_parse_multipart4);
+  subtest("test_clask_request_parse_multipart5", test_clask_request_parse_multipart5);
   subtest("test_clask_to_wstring", test_clask_to_wstring);
   subtest("test_clask_request_cookie_value", test_clask_request_cookie_value);
   subtest("test_clask_request_uri_param", test_clask_request_uri_param);


### PR DESCRIPTION
Fixes multipart parsing so part bodies are sliced before the next boundary and multiple parts are parsed without boundary data leaking into the body. Adds coverage for body contents and multiple parts.