### PR TITLE
Prefer literal routes over placeholders

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -1602,15 +1602,21 @@ inline bool server_t::match(route_method method, const std::string& s, const std
     auto segment = parse_path_segment(s, offset);
     bool found = false;
     for (const auto& vv : n->children) {
-      if (vv.placeholder) {
-        args.emplace_back(url_decode(segment.value));
+      if (!vv.placeholder
+          && (vv.name == segment.value || (vv.name.empty() && segment.value.empty()))) {
         n = &vv;
         found = true;
         break;
-      } else if (vv.name == segment.value || (vv.name.empty() && segment.value.empty())) {
-        n = &vv;
-        found = true;
-        break;
+      }
+    }
+    if (!found) {
+      for (const auto& vv : n->children) {
+        if (vv.placeholder) {
+          args.emplace_back(url_decode(segment.value));
+          n = &vv;
+          found = true;
+          break;
+        }
       }
     }
     if (!found)

--- a/test.cxx
+++ b/test.cxx
@@ -283,6 +283,25 @@ void test_clask_root_route_match() {
   _ok(miss == false, R"(miss == false)");
 }
 
+void test_clask_literal_route_priority() {
+  auto s = clask::server();
+  s.GET("/:id", [](clask::request& req) -> std::string {
+    return req.args[0];
+  });
+  s.GET("/about", [](clask::request& /*req*/) -> std::string {
+    return "about";
+  });
+
+  auto matched_literal = false;
+  auto result = s.test_match("GET", "/about", [&](const clask::func_t& fn, const std::vector<std::string>& args) {
+    clask::request req("GET", "/about", "/about", {}, {}, "");
+    req.args = args;
+    matched_literal = fn.f_string(req) == "about";
+  });
+  _ok(result == true, R"(result == true)");
+  _ok(matched_literal == true, R"(matched_literal == true)");
+}
+
 void test_clask_static_dir_route_match() {
   auto s = clask::server();
   s.static_dir("/", "./public");
@@ -541,6 +560,7 @@ int main() {
   subtest("test_clask_post_route_match", test_clask_post_route_match);
   subtest("test_clask_query_route_match", test_clask_query_route_match);
   subtest("test_clask_root_route_match", test_clask_root_route_match);
+  subtest("test_clask_literal_route_priority", test_clask_literal_route_priority);
   subtest("test_clask_static_dir_route_match", test_clask_static_dir_route_match);
   subtest("test_clask_parse_listen_address", test_clask_parse_listen_address);
   subtest("test_clask_parse_route_method", test_clask_parse_route_method);


### PR DESCRIPTION
Fixes route matching so literal routes take precedence over placeholder routes at the same level. Adds coverage for a literal route that coexists with a placeholder route.