### PR TITLE
Validate Content-Length header

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -1205,6 +1205,22 @@ inline request_read_result make_request_read_success(
   };
 }
 
+inline std::optional<size_t> parse_content_length(const std::string& value) {
+  if (value.empty() || value[0] == '-') {
+    return std::nullopt;
+  }
+  try {
+    size_t parsed_len = 0;
+    auto parsed = std::stoull(value, &parsed_len, 10);
+    if (parsed_len != value.size()) {
+      return std::nullopt;
+    }
+    return static_cast<size_t>(parsed);
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
 inline request_read_result read_request_from_socket(int s) {
   char buf[16384];
   const char *method, *path;
@@ -1264,7 +1280,11 @@ inline request_read_result read_request_from_socket(int s) {
     auto val = std::string(headers[n].value, headers[n].value_len);
     camelize(key);
     if (key == "Content-Length") {
-      content_length = std::stoi(val);
+      auto parsed_content_length = parse_content_length(val);
+      if (!parsed_content_length.has_value()) {
+        return make_request_read_error(400, "Bad Request", "Invalid Content-Length");
+      }
+      content_length = *parsed_content_length;
       has_content_length = true;
     } else if (key == "Connection") {
       for (auto& c : val) c = (char) std::tolower(c);

--- a/test.cxx
+++ b/test.cxx
@@ -459,6 +459,41 @@ void test_clask_request_read_result_helpers() {
   }
 }
 
+void test_clask_parse_content_length() {
+  {
+    auto result = clask::parse_content_length("123");
+    _ok(result.has_value() == true, R"(result.has_value() == true)");
+    _ok(*result == 123, R"(*result == 123)");
+  }
+  _ok(clask::parse_content_length("").has_value() == false, R"(clask::parse_content_length("").has_value() == false)");
+  _ok(clask::parse_content_length("-1").has_value() == false, R"(clask::parse_content_length("-1").has_value() == false)");
+  _ok(clask::parse_content_length("abc").has_value() == false, R"(clask::parse_content_length("abc").has_value() == false)");
+  _ok(clask::parse_content_length("12x").has_value() == false, R"(clask::parse_content_length("12x").has_value() == false)");
+}
+
+void test_clask_read_request_invalid_content_length() {
+  int fds[2];
+  auto socket_result = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+  _ok(socket_result == 0, R"(socket_result == 0)");
+
+  const std::string request =
+      "POST / HTTP/1.1\r\n"
+      "Host: localhost\r\n"
+      "Content-Length: abc\r\n"
+      "\r\n";
+  auto written = write(fds[0], request.data(), request.size());
+  _ok(written == (ssize_t) request.size(), R"(written == (ssize_t) request.size())");
+  shutdown(fds[0], SHUT_WR);
+
+  auto result = clask::read_request_from_socket(fds[1]);
+  _ok(result.ok == false, R"(result.ok == false)");
+  _ok(result.error_code == 400, R"(result.error_code == 400)");
+  _ok(std::string(result.error_body) == "Invalid Content-Length", R"(std::string(result.error_body) == "Invalid Content-Length")");
+
+  closesocket(fds[0]);
+  closesocket(fds[1]);
+}
+
 void test_clask_parent_reference_guard() {
   _ok(clask::contains_parent_reference("../secret") == true, R"(clask::contains_parent_reference("../secret") == true)");
   _ok(clask::contains_parent_reference("safe/path") == false, R"(clask::contains_parent_reference("safe/path") == false)");
@@ -586,6 +621,8 @@ int main() {
   subtest("test_clask_parse_route_method", test_clask_parse_route_method);
   subtest("test_clask_parse_path_segment", test_clask_parse_path_segment);
   subtest("test_clask_request_read_result_helpers", test_clask_request_read_result_helpers);
+  subtest("test_clask_parse_content_length", test_clask_parse_content_length);
+  subtest("test_clask_read_request_invalid_content_length", test_clask_read_request_invalid_content_length);
   subtest("test_clask_parent_reference_guard", test_clask_parent_reference_guard);
   subtest("test_clask_server_runtime_helpers", test_clask_server_runtime_helpers);
   subtest("test_clask_fluent_server_setup", test_clask_fluent_server_setup);


### PR DESCRIPTION
Adds strict Content-Length parsing and returns a bad request result for invalid values instead of allowing conversion exceptions. Adds coverage for invalid header values read from a socket.