### PR TITLE
Bound request body by Content-Length

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -1300,13 +1300,17 @@ inline request_read_result read_request_from_socket(int s) {
     auto rest = content_length - (buflen - pret);
     buflen = 0;
     while (rest > 0) {
-      while ((rret = recv(s, buf + buflen, (int) (sizeof(buf) - buflen), MSG_NOSIGNAL)) == -1 && errno == EINTR);
+      auto chunk_size = std::min(rest, sizeof(buf));
+      while ((rret = recv(s, buf + buflen, (int) chunk_size, MSG_NOSIGNAL)) == -1 && errno == EINTR);
       if (rret <= 0) {
         return make_request_read_error(0, "", "");
       }
       req_body.append(buf, rret);
-      rest -= rret;
+      rest -= (size_t) rret;
     }
+  }
+  if (has_content_length && req_body.size() > content_length) {
+    req_body.resize(content_length);
   }
 
   return make_request_read_success(

--- a/test.cxx
+++ b/test.cxx
@@ -494,6 +494,30 @@ void test_clask_read_request_invalid_content_length() {
   closesocket(fds[1]);
 }
 
+void test_clask_read_request_content_length_bounds_body() {
+  int fds[2];
+  auto socket_result = socketpair(AF_UNIX, SOCK_STREAM, 0, fds);
+  _ok(socket_result == 0, R"(socket_result == 0)");
+
+  const std::string request =
+      "POST / HTTP/1.1\r\n"
+      "Host: localhost\r\n"
+      "Content-Length: 3\r\n"
+      "\r\n"
+      "abcdef";
+  auto written = write(fds[0], request.data(), request.size());
+  _ok(written == (ssize_t) request.size(), R"(written == (ssize_t) request.size())");
+  shutdown(fds[0], SHUT_WR);
+
+  auto result = clask::read_request_from_socket(fds[1]);
+  _ok(result.ok == true, R"(result.ok == true)");
+  _ok(result.req.has_value() == true, R"(result.req.has_value() == true)");
+  _ok(result.req->body == "abc", R"(result.req->body == "abc")");
+
+  closesocket(fds[0]);
+  closesocket(fds[1]);
+}
+
 void test_clask_parent_reference_guard() {
   _ok(clask::contains_parent_reference("../secret") == true, R"(clask::contains_parent_reference("../secret") == true)");
   _ok(clask::contains_parent_reference("safe/path") == false, R"(clask::contains_parent_reference("safe/path") == false)");
@@ -623,6 +647,7 @@ int main() {
   subtest("test_clask_request_read_result_helpers", test_clask_request_read_result_helpers);
   subtest("test_clask_parse_content_length", test_clask_parse_content_length);
   subtest("test_clask_read_request_invalid_content_length", test_clask_read_request_invalid_content_length);
+  subtest("test_clask_read_request_content_length_bounds_body", test_clask_read_request_content_length_bounds_body);
   subtest("test_clask_parent_reference_guard", test_clask_parent_reference_guard);
   subtest("test_clask_server_runtime_helpers", test_clask_server_runtime_helpers);
   subtest("test_clask_fluent_server_setup", test_clask_fluent_server_setup);


### PR DESCRIPTION
Ensures request bodies are limited to the declared Content-Length and reads only the remaining body bytes when additional data is needed. Adds coverage for extra bytes after the declared body.