### PR TITLE
Trim all-whitespace strings

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -627,10 +627,12 @@ inline std::string camelize(std::string& s) {
 
 inline void trim_string(std::string& s, const std::string& cutsel = " \t\v\r\n") {
   auto left = s.find_first_not_of(cutsel);
-  if (left != std::string::npos) {
-    auto right = s.find_last_not_of(cutsel);
-    s = s.substr(left, right - left + 1);
+  if (left == std::string::npos) {
+    s.clear();
+    return;
   }
+  auto right = s.find_last_not_of(cutsel);
+  s = s.substr(left, right - left + 1);
 }
 
 inline std::vector<std::string> split_string(const std::string& s, char delim, size_t max_elems = -1) {

--- a/test.cxx
+++ b/test.cxx
@@ -154,6 +154,19 @@ void test_clask_to_wstring() {
   _ok(clask::to_wstring("あいうえお") == L"あいうえお", R"(clask::to_wstring("あいうえお") == L"あいうえお")");
 }
 
+void test_clask_trim_string() {
+  {
+    std::string value = "  hello \t";
+    clask::trim_string(value);
+    _ok(value == "hello", R"(value == "hello")");
+  }
+  {
+    std::string value = " \t\r\n";
+    clask::trim_string(value);
+    _ok(value == "", R"(value == "")");
+  }
+}
+
 void test_clask_request_cookie_value() {
   {
     clask::request req(
@@ -633,6 +646,7 @@ int main() {
   subtest("test_clask_request_parse_multipart4", test_clask_request_parse_multipart4);
   subtest("test_clask_request_parse_multipart5", test_clask_request_parse_multipart5);
   subtest("test_clask_to_wstring", test_clask_to_wstring);
+  subtest("test_clask_trim_string", test_clask_trim_string);
   subtest("test_clask_request_cookie_value", test_clask_request_cookie_value);
   subtest("test_clask_request_uri_param", test_clask_request_uri_param);
   subtest("test_clask_post_route_match", test_clask_post_route_match);


### PR DESCRIPTION
Fixes trim_string so inputs made entirely of trim characters become empty strings instead of retaining whitespace. Adds coverage for normal and all-whitespace inputs.