### PR TITLE
Avoid signed char classification in url_encode

### DIFF
--- a/clask/core.hpp
+++ b/clask/core.hpp
@@ -668,7 +668,8 @@ inline std::string url_encode(const std::string &value, bool escape_slash = true
   os.fill('0');
   os << std::hex;
   for (char c : value) {
-    if (isalnum(c) || c == '-' || c == '_' || c == '.' || c == '~') {
+    auto uc = static_cast<unsigned char>(c);
+    if (std::isalnum(uc) || c == '-' || c == '_' || c == '.' || c == '~') {
       os << c;
       continue;
     }

--- a/test.cxx
+++ b/test.cxx
@@ -167,6 +167,12 @@ void test_clask_trim_string() {
   }
 }
 
+void test_clask_url_encode() {
+  _ok(clask::url_encode("hello world") == "hello%20world", "space is encoded");
+  _ok(clask::url_encode("/files/name", false) == "/files/name", R"(clask::url_encode("/files/name", false) == "/files/name")");
+  _ok(clask::url_encode("あ") == "%E3%81%82", "utf-8 bytes are encoded");
+}
+
 void test_clask_request_cookie_value() {
   {
     clask::request req(
@@ -647,6 +653,7 @@ int main() {
   subtest("test_clask_request_parse_multipart5", test_clask_request_parse_multipart5);
   subtest("test_clask_to_wstring", test_clask_to_wstring);
   subtest("test_clask_trim_string", test_clask_trim_string);
+  subtest("test_clask_url_encode", test_clask_url_encode);
   subtest("test_clask_request_cookie_value", test_clask_request_cookie_value);
   subtest("test_clask_request_uri_param", test_clask_request_uri_param);
   subtest("test_clask_post_route_match", test_clask_post_route_match);


### PR DESCRIPTION
Updates url_encode to classify characters through unsigned char values to avoid undefined behavior with non-ASCII bytes. Adds coverage for UTF-8 input encoding.